### PR TITLE
Maps and structs equal

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ defmodule UsersTest do
       alice = Factory.insert(:user, name: "Alice")
       bob = Factory.insert(:user, name: "Bob")
 
-      updated_names = 
+      updated_names =
         [{alice, %{name: "Alice A."}, {bob, %{name: "Bob B."}}}]
         |> Users.update_all()
         |> Enum.map(& &1.name)
@@ -138,7 +138,7 @@ defmodule UsersTest do
         |> Enum.map(& &1.name)
         |> assert_lists_equal(["Alice A.", "Bob B."])
 
-      assert_lists_equal(result, Users.list_all(), &assert_structs_equal(&1, &2, [:name]))
+      assert_lists_equal(result, Users.list_all(), &structs_equal(&1, &2, [:name]))
     end
   end
 end
@@ -154,7 +154,7 @@ But `assert_lists_equal` also solves the other problem we had when we wanted to
 compare lists of structs. That second assertion:
 
 ```elixir
-assert_lists_equal(result, Users.list_all(), &assert_structs_equal(&1, &2, [:name]))
+assert_lists_equal(result, Users.list_all(), &structs_equal(&1, &2, [:name]))
 ```
 
 is comparing that the two lists are equal, but we give it a custom comparison

--- a/lib/assertions.ex
+++ b/lib/assertions.ex
@@ -488,6 +488,40 @@ defmodule Assertions do
   end
 
   @doc """
+  Compares two maps like `assert_maps_equal/3` without raising an error when they don't match.
+  This is to be used with `assert_list_equal/3`.
+
+      iex> assert maps_equal(%{a: 0, b: 0, c: 0}, %{a: 0, b: 0, c: 0}, [:a, :b, :c])
+      true
+
+      iex> refute maps_equal(%{a: 0, b: 0, c: 0}, %{a: 1, b: 1, c: 1}, [:a, :b, :c])
+      false
+
+      iex> assert maps_equal(%{a: 1, b: 2, c: 3}, %{c: 3, a: 1, b: 2}, [:a, :b, :c, :x])
+      true
+
+      iex> assert maps_equal(%{a: 1, b: 2222, c: 3333}, %{a: 1, b: 2, c: 3}, [:a])
+      true
+
+      iex> refute maps_equal(%{a: 1, b: 2222, c: 3333}, %{a: 1, b: 2000, c: 3000}, [:b, :c])
+      false
+
+      iex> assert maps_equal(%{a: 0}, %{b: 0}, fn left, right -> left.a == right.b end)
+      true
+
+      iex> refute maps_equal( %{a: 0}, %{b: 9}, fn left, right -> left.a == right.b end )
+      false
+  """
+  @spec maps_equal(map(), map(), [atom()] | (term(), term() -> boolean)) :: boolean
+  def maps_equal(left, right, keys) when is_list(keys) do
+    Map.take(left, keys) == Map.take(right, keys)
+  end
+
+  def maps_equal(left, right, fun) when is_function(fun) do
+    fun.(left, right)
+  end
+
+  @doc """
   Asserts that all maps, structs or keyword lists in `list` have the same
   `value` for `key`.
 

--- a/lib/assertions.ex
+++ b/lib/assertions.ex
@@ -558,11 +558,9 @@ defmodule Assertions do
       iex> refute structs_equal(date_time, date, [:month, :day])
       false
   """
-  @spec structs_equal(struct(), struct(), [atom()] | (term(), term() -> boolean)) ::
-          boolean()
+  @spec structs_equal(struct(), struct(), [atom()] | (term(), term() -> boolean)) :: boolean()
   def structs_equal(left, right, keys_or_function) do
-    left.__struct__ == right.__struct__ and
-      maps_equal(left, right, keys_or_function)
+    left.__struct__ == right.__struct__ and maps_equal(left, right, keys_or_function)
   end
 
   @doc """

--- a/lib/assertions.ex
+++ b/lib/assertions.ex
@@ -522,6 +522,50 @@ defmodule Assertions do
   end
 
   @doc """
+  Compares two structs like `assert_structs_equal/3` without raising an error when they don't match.
+  This is to be used with `assert_list_equal/3`.
+
+      iex> assert structs_equal(
+      ...>   %Date{year: 2020, month: 3, day: 7},
+      ...>   %Date{year: 2020, month: 3, day: 7},
+      ...>   [:month, :day]
+      ...> )
+      true
+
+      iex> refute structs_equal(
+      ...>   %Date{year: 2020, month: 3, day: 7},
+      ...>   %Date{year: 2020, month: 3, day: 8},
+      ...>   [:month, :day]
+      ...> )
+      false
+
+      iex> assert structs_equal(
+      ...>   %Date{year: 2020, month: 3, day: 19},
+      ...>   %Date{year: 2020, month: 11, day: 3},
+      ...>   fn left, right -> left.month == right.day end
+      ...> )
+      true
+
+      iex> refute structs_equal(
+      ...>   %Date{year: 2020, month: 3, day: 19},
+      ...>   %Date{year: 2020, month: 11, day: 20},
+      ...>   fn left, right -> left.month == right.day end
+      ...> )
+      false
+
+      iex> assert %DateTime{} = date_time = DateTime.utc_now()
+      iex> assert %Date{} = date = struct(Date, Map.take(date_time, [:year, :month, :day]))
+      iex> refute structs_equal(date_time, date, [:month, :day])
+      false
+  """
+  @spec structs_equal(struct(), struct(), [atom()] | (term(), term() -> boolean)) ::
+          boolean()
+  def structs_equal(left, right, keys_or_function) do
+    left.__struct__ == right.__struct__ and
+      maps_equal(left, right, keys_or_function)
+  end
+
+  @doc """
   Asserts that all maps, structs or keyword lists in `list` have the same
   `value` for `key`.
 

--- a/test/assertions_test.exs
+++ b/test/assertions_test.exs
@@ -7,7 +7,7 @@ defmodule AssertionsTest do
 
   describe "assert!/1" do
     test "fails if either side of >, >=, < or <= is nil" do
-      assert! nil > 0
+      assert!(nil > 0)
     rescue
       error in [ExUnit.AssertionError] ->
         assert nil == error.left
@@ -19,7 +19,7 @@ defmodule AssertionsTest do
 
   describe "refute!/1" do
     test "fails if either side of >, >=, < or <= is nil" do
-      refute! nil > 0
+      refute!(nil > 0)
     rescue
       error in [ExUnit.AssertionError] ->
         assert nil == error.left

--- a/test/assertions_test.exs
+++ b/test/assertions_test.exs
@@ -51,7 +51,13 @@ defmodule AssertionsTest do
     test "works when composed with other assertions" do
       list1 = [DateTime.utc_now(), DateTime.utc_now()]
       list2 = [DateTime.utc_now(), DateTime.utc_now()]
-      assert_lists_equal(list1, list2, &assert_structs_equal(&1, &2, [:year, :month]))
+      assert_lists_equal(list1, list2, &structs_equal(&1, &2, [:year, :month]))
+    end
+
+    test "works when list elements are in different order" do
+      list1 = [%{foo: 1}, %{foo: 2}, %{foo: 3}]
+      list2 = [%{foo: 2}, %{foo: 1}, %{foo: 3}]
+      assert_lists_equal(list1, list2, &maps_equal(&1, &2, [:foo]))
     end
   end
 


### PR DESCRIPTION
`assert_maps_equal/3` and `assert_structs_equal/3` break the "order does not matter" feature of `assert_lists_equal/3`.  I add this test to the test suite:

```elixir
test "works when list elements are in different order" do
  list1 = [%{foo: 1}, %{foo: 2}, %{foo: 3}]
  list2 = [%{foo: 2}, %{foo: 1}, %{foo: 3}]
  assert_lists_equal(list1, list2, &assert_maps_equal(&1, &2, [:foo]))
end
```

The two lists have the same elements, but in different orders.  This should pass.  But it doesn't:

```
1) test assert_lists_equal/2 works when list elements are in different order (AssertionsTest)
     test/assertions_test.exs:57
     Values for :foo not equal!
     code:  assert_maps_equal(x1, x2, [:foo])
     arguments:

         # 1
         %{foo: 2}

         # 2
         %{foo: 1}

     left:  %{foo: 2}
     right: %{foo: 1}
     stacktrace:
       test/assertions_test.exs:60: anonymous fn/2 in AssertionsTest."test assert_lists_equal/2 works when list elements are in different order"/1
       (elixir) lib/enum.ex:2962: Enum.find_index_list/3
       (assertions) lib/assertions/comparisons.ex:22: anonymous fn/3 in Assertions.Comparisons.compare/3
       (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
       (assertions) lib/assertions/comparisons.ex:15: Assertions.Comparisons.compare_lists/3
       test/assertions_test.exs:60: (test)
```

The failing assertion is `assert_maps_equal/3`, and it's failing while comparing the first elements of the two lists.  The very first time that the elements are out of order.

I've added `maps_equal/3` and `structs_equal/3` to do just simple true/false comparisons.  When I replace `assert_maps_equal/3` with `maps_equal/3` above, it passes as expected.  I changed the examples in the README.