### PR TITLE
Include interfaces and unions for absinthe helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.16.1
+### Bugs
+* Fixed bug with interfaces and unions not showing correctly in
+    `Assertions.Absinthe.fields_for/2,3` and `Assertions.Absinthe.document_for/2,3`.
+
 ## 0.16.0
 ### Features
 * Added `Assertions.AbsintheCase`

--- a/lib/assertions/absinthe.ex
+++ b/lib/assertions/absinthe.ex
@@ -125,6 +125,18 @@ defmodule Assertions.Absinthe do
     :reject
   end
 
+  defp get_fields(%Absinthe.Type.Interface{fields: fields} = type, schema, nesting) do
+    implementors = Map.get(schema.__absinthe_interface_implementors__(), type.identifier)
+    IO.inspect(implementors)
+    Enum.reduce(fields, [], fn {_, value}, acc ->
+      case fields_for(schema, value.type, nesting - 1) do
+        :reject -> acc
+        :scalar -> [String.to_atom(value.name) | acc]
+        list -> [{String.to_atom(value.name), list} | acc]
+      end
+    end)
+  end
+
   defp get_fields(%{fields: fields}, schema, nesting) do
     Enum.reduce(fields, [], fn {_, value}, acc ->
       case fields_for(schema, value.type, nesting - 1) do

--- a/lib/assertions/absinthe.ex
+++ b/lib/assertions/absinthe.ex
@@ -70,7 +70,7 @@ defmodule Assertions.Absinthe do
   def document_for(schema, type, nesting) do
     schema
     |> fields_for(type, nesting)
-    |> format_fields(type, 0)
+    |> format_fields(type, 0, schema)
     |> List.to_string()
   end
 
@@ -126,15 +126,27 @@ defmodule Assertions.Absinthe do
   end
 
   defp get_fields(%Absinthe.Type.Interface{fields: fields} = type, schema, nesting) do
+    interface_fields =
+      Enum.reduce(fields, [], fn {_, value}, acc ->
+        case fields_for(schema, value.type, nesting - 1) do
+          :reject -> acc
+          :scalar -> [String.to_atom(value.name) | acc]
+          list -> [{String.to_atom(value.name), list} | acc]
+        end
+      end)
+
     implementors = Map.get(schema.__absinthe_interface_implementors__(), type.identifier)
-    IO.inspect(implementors)
-    Enum.reduce(fields, [], fn {_, value}, acc ->
-      case fields_for(schema, value.type, nesting - 1) do
-        :reject -> acc
-        :scalar -> [String.to_atom(value.name) | acc]
-        list -> [{String.to_atom(value.name), list} | acc]
-      end
-    end)
+
+    implementor_fields =
+      Enum.map(implementors, fn type ->
+        {type, fields_for(schema, type, nesting) -- interface_fields -- [:__typename]}
+      end)
+
+    {interface_fields, implementor_fields}
+  end
+
+  defp get_fields(%Absinthe.Type.Union{types: types}, schema, nesting) do
+    {[], Enum.map(types, &{&1, fields_for(schema, &1, nesting)})}
   end
 
   defp get_fields(%{fields: fields}, schema, nesting) do
@@ -142,7 +154,8 @@ defmodule Assertions.Absinthe do
       case fields_for(schema, value.type, nesting - 1) do
         :reject -> acc
         :scalar -> [String.to_atom(value.name) | acc]
-        list -> [{String.to_atom(value.name), list} | acc]
+        list when is_list(list) -> [{String.to_atom(value.name), list} | acc]
+        tuple -> [{String.to_atom(value.name), tuple} | acc]
       end
     end)
   end
@@ -151,29 +164,48 @@ defmodule Assertions.Absinthe do
     :scalar
   end
 
-  defp format_fields(fields, _, 0) do
+  defp format_fields(fields, _, 0, schema) do
     fields =
       fields
-      |> Enum.reduce({[], 2}, &do_format_fields/2)
+      |> Enum.reduce({[], 2}, &do_format_fields(&1, &2, schema))
       |> elem(0)
 
     Enum.reverse(fields)
   end
 
-  defp format_fields(fields, type, left_pad) do
+  defp format_fields({interface_fields, implementor_fields}, type, left_pad, schema)
+       when is_list(interface_fields) do
+    interface_fields =
+      interface_fields
+      |> Enum.reduce({["#{camelize(type)} {\n"], left_pad + 2}, &do_format_fields(&1, &2, schema))
+      |> elem(0)
+
+    implementor_fields =
+      implementor_fields
+      |> Enum.map(fn {type, fields} ->
+        type_info = schema.__absinthe_type__(type)
+        [_ | rest] = format_fields(fields, type, left_pad + 2, schema)
+        fields = ["...on #{type_info.name} {\n" | rest]
+        [padding(left_pad + 2), fields]
+      end)
+
+    Enum.reverse(["}\n", padding(left_pad), implementor_fields | interface_fields])
+  end
+
+  defp format_fields(fields, type, left_pad, schema) do
     fields =
       fields
-      |> Enum.reduce({["#{camelize(type)} {\n"], left_pad + 2}, &do_format_fields/2)
+      |> Enum.reduce({["#{camelize(type)} {\n"], left_pad + 2}, &do_format_fields(&1, &2, schema))
       |> elem(0)
 
     Enum.reverse(["}\n", padding(left_pad) | fields])
   end
 
-  defp do_format_fields({type, sub_fields}, {acc, left_pad}) do
-    {[format_fields(sub_fields, type, left_pad), padding(left_pad) | acc], left_pad}
+  defp do_format_fields({type, sub_fields}, {acc, left_pad}, schema) do
+    {[format_fields(sub_fields, type, left_pad, schema), padding(left_pad) | acc], left_pad}
   end
 
-  defp do_format_fields(type, {acc, left_pad}) do
+  defp do_format_fields(type, {acc, left_pad}, _) do
     {["\n", camelize(type), padding(left_pad) | acc], left_pad}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Assertions.MixProject do
   def project do
     [
       app: :assertions,
-      version: "0.16.0",
+      version: "0.16.1",
       elixir: "~> 1.7",
       deps: deps(),
       description: description(),


### PR DESCRIPTION
This will get unions and interfaces showing up correctly in the new Absinthe helpers.