### PR TITLE
Fix: include .formatter.exs in package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Assertions.MixProject do
 
   defp package do
     [
-      files: ~w(lib mix.exs README.md LICENSE),
+      files: ~w(lib mix.exs README.md LICENSE .formatter.exs),
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/devonestes/assertions"}
     ]


### PR DESCRIPTION
Adds onto #17, closes #16.

The formatter file isn't being published to hex, so this doesn't work when importing deps in our apps.