### PR TITLE
add missing import for example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ But, with `assertions`, you can write that test like this:
 ```elixir
 defmodule UsersTest do
   use ExUnit.Case, async: true
-  import Assertions, only: [assert_lists_equal: 2]
+  import Assertions, only: [assert_lists_equal: 2, assert_structs_equal: 3]
 
   describe "update_all/2" do
     test "updates the given users in the database and returns those updated users" do


### PR DESCRIPTION
The `Expressive assertion` example also required `assert_structs_equal` to be imported to work, as it's mentioned on line 141.

This commit adds it in, just so it's not missed.

Thanks for the great package! It's already saved me lots of work.