### PR TITLE
Fix compilation errors

### DIFF
--- a/lib/assertions/absinthe.ex
+++ b/lib/assertions/absinthe.ex
@@ -19,7 +19,7 @@ defmodule Assertions.Absinthe do
 
   and then all functions in this module will not need the schema passed explicitly into it.
   """
-  if match?({:module, _}, Code.ensure_compiled(Absinthe)) do
+  if Code.ensure_loaded?(Absinthe) do
     require Assertions
 
     require ExUnit.Assertions
@@ -104,8 +104,8 @@ defmodule Assertions.Absinthe do
 
         iex> query = "{ user { #{document_for(:user, 2)} } }"
         iex> assert_response_matches(query) do
-           %{"user" => %{"name" => "B" <> _, "posts" => posts}}
-        end
+        ...>    %{"user" => %{"name" => "B" <> _, "posts" => posts}}
+        ...> end
         iex> assert length(posts) == 1
     """
     @spec assert_response_matches(module(), String.t(), Keyword.t(), Macro.expr()) ::


### PR DESCRIPTION
Fixes #22
Replaces #24 

From my reading of the docs and other research, it looks like `Code.ensure_loaded?` is a better way to check whether an optional dependency module exists or not. Details below. This PR preserves the intention of only including Absinthe-related code when Absinthe is present in the parent project. #24 was a temporary fix to disable the check as I understand it.

This also fixes a formatting-related test failure in the doc tests for `assertions/absinthe.ex`. I still get 3 test failures in the doc tests (with Elixir 1.12.3), but I'm not sure what the problem is or how to fix them. The errors all happen in `format_fields` with the message:

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for :scalar of type Atom. This protocol is implemented for the following type(s): HashSet, Range, Map, Function, List, Stream, Date.Range, HashDict, GenEvent.Stream, MapSet, File.Stream, IO.Stream
```

Details:
- The [Elixir docs for `Code.ensure_compiled`](https://hexdocs.pm/elixir/1.12/Code.html#ensure_compiled!/1) say:
  > Given this function halts compilation, use it carefully. In particular, avoid using it to guess which modules are in the system.
- [In an Elixir Forum post](https://elixirforum.com/t/elixir-proposal-optional-dependencies-for-deploy/3334/2), Jose Valim suggests using `Code.ensure_loaded?` to check if a dependency is loaded or not.