### PR TITLE
Fixes failing doctests

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 22.3.4.1
-elixir 1.10.0-otp-22
+erlang 23.3.4
+elixir 1.10.4

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 23.3.4
-elixir 1.10.4
+erlang 22.3.4.1
+elixir 1.10.0-otp-22

--- a/lib/assertions/absinthe.ex
+++ b/lib/assertions/absinthe.ex
@@ -52,10 +52,12 @@ defmodule Assertions.Absinthe do
     fields with resolver functions that aren't tested in at least some fashion.
 
     ## Example
+
         iex> document_for(:user, 2)
         \"""
                     posts {\n                  title\n                  __typename\n                }\n                name\n                __typename
         \"""
+
     """
     @spec document_for(module(), atom(), non_neg_integer(), Keyword.t()) :: String.t()
     def document_for(schema, type, nesting, overrides) do
@@ -73,9 +75,11 @@ defmodule Assertions.Absinthe do
     field in the response.
 
     ## Example
+
         iex> query = "{ user { #{document_for(:user, 2)} } }"
         iex> expected = %{"user" => %{"__typename" => "User", "name" => "Bob", "posts" => [%{"__typename" => "Post", "title" => "A post"}]}}
         iex> assert_response_equals(query, expected)
+
     """
     @spec assert_response_equals(module(), String.t(), map(), Keyword.t()) :: :ok | no_return()
     def assert_response_equals(schema, document, expected_response, options) do
@@ -91,11 +95,13 @@ defmodule Assertions.Absinthe do
     making separate assertions further down in your test.
 
     ## Example
+
         iex> query = "{ user { #{document_for(:user, 2)} } }"
         iex> assert_response_matches(query) do
         ...>%{"user" => %{"name" => "B" <> _, "posts" => posts}}
         ...>end
         iex> assert length(posts) == 1
+
     """
     @spec assert_response_matches(module(), String.t(), Keyword.t(), Macro.expr()) ::
             :ok | no_return()

--- a/lib/assertions/absinthe.ex
+++ b/lib/assertions/absinthe.ex
@@ -52,37 +52,7 @@ defmodule Assertions.Absinthe do
     fields with resolver functions that aren't tested in at least some fashion.
 
     ## Example
-        iex> ExUnit.start()
-        iex>
-        iex> defmodule MyApp.Schema do
-        ...>use Absinthe.Schema
-        ...>object :user do
-        ...>field :name, :string do
-        ...>resolve(fn _, _, _ -> {:ok, "Bob"} end)
-        ...>end
-        ...>
-        ...>field :posts, non_null(list_of(:post)) do
-        ...>resolve(fn _, _, _ -> {:ok, [%{}]} end)
-        ...>end
-        ...>end
-        ...>object :post do
-        ...>field :title, :string do
-        ...>resolve(fn _, _, _ -> {:ok, "A post"} end)
-        ...>end
-        ...>end
-        ...>query do
-        ...>field :user, :user do
-        ...>arg(:name, :string)
-        ...>resolve(fn _, _, _ -> {:ok, %{}} end)
-        ...>end
-        ...>end
-        ...>end
-        iex>
-        ...>defmodule MyApp.DataCase do
-        ...>use Assertions.AbsintheCase, async: true, schema: MyApp.Schema
-        ...>end
-        iex>
-        iex> MyApp.DataCase.document_for(:user, 2)
+        iex> document_for(:user, 2)
         \"""
                     posts {\n                  title\n                  __typename\n                }\n                name\n                __typename
         \"""
@@ -103,39 +73,9 @@ defmodule Assertions.Absinthe do
     field in the response.
 
     ## Example
-        iex> ExUnit.start()
-        iex>
-        iex> defmodule MyApp.Schema do
-        ...>use Absinthe.Schema
-        ...>object :user do
-        ...>field :name, :string do
-        ...>resolve(fn _, _, _ -> {:ok, "Bob"} end)
-        ...>end
-        ...>
-        ...>field :posts, non_null(list_of(:post)) do
-        ...>resolve(fn _, _, _ -> {:ok, [%{}]} end)
-        ...>end
-        ...>end
-        ...>object :post do
-        ...>field :title, :string do
-        ...>resolve(fn _, _, _ -> {:ok, "A post"} end)
-        ...>end
-        ...>end
-        ...>query do
-        ...>field :user, :user do
-        ...>arg(:name, :string)
-        ...>resolve(fn _, _, _ -> {:ok, %{}} end)
-        ...>end
-        ...>end
-        ...>end
-        iex>
-        ...>defmodule MyApp.DataCase do
-        ...>use Assertions.AbsintheCase, async: true, schema: MyApp.Schema
-        ...>end
-        iex>
-        iex> query = "{ user { #{MyApp.DataCase.document_for(:user, 2)} } }"
+        iex> query = "{ user { #{document_for(:user, 2)} } }"
         iex> expected = %{"user" => %{"__typename" => "User", "name" => "Bob", "posts" => [%{"__typename" => "Post", "title" => "A post"}]}}
-        iex> MyApp.DataCase.assert_response_equals(query, expected)
+        iex> assert_response_equals(query, expected)
     """
     @spec assert_response_equals(module(), String.t(), map(), Keyword.t()) :: :ok | no_return()
     def assert_response_equals(schema, document, expected_response, options) do

--- a/lib/assertions/absinthe.ex
+++ b/lib/assertions/absinthe.ex
@@ -52,18 +52,39 @@ defmodule Assertions.Absinthe do
     fields with resolver functions that aren't tested in at least some fashion.
 
     ## Example
-
-        iex> document_for(:user, 2)
+        iex> ExUnit.start()
+        iex>
+        iex> defmodule MyApp.Schema do
+        ...>use Absinthe.Schema
+        ...>object :user do
+        ...>field :name, :string do
+        ...>resolve(fn _, _, _ -> {:ok, "Bob"} end)
+        ...>end
+        ...>
+        ...>field :posts, non_null(list_of(:post)) do
+        ...>resolve(fn _, _, _ -> {:ok, [%{}]} end)
+        ...>end
+        ...>end
+        ...>object :post do
+        ...>field :title, :string do
+        ...>resolve(fn _, _, _ -> {:ok, "A post"} end)
+        ...>end
+        ...>end
+        ...>query do
+        ...>field :user, :user do
+        ...>arg(:name, :string)
+        ...>resolve(fn _, _, _ -> {:ok, %{}} end)
+        ...>end
+        ...>end
+        ...>end
+        iex>
+        ...>defmodule MyApp.DataCase do
+        ...>use Assertions.AbsintheCase, async: true, schema: MyApp.Schema
+        ...>end
+        iex>
+        iex> MyApp.DataCase.document_for(:user, 2)
         \"""
-        name
-        age
-        posts {
-          title
-          subtitle
-        }
-        comments {
-          body
-        }
+                    posts {\n                  title\n                  __typename\n                }\n                name\n                __typename
         \"""
     """
     @spec document_for(module(), atom(), non_neg_integer(), Keyword.t()) :: String.t()

--- a/test/assertions/absinthe_test.exs
+++ b/test/assertions/absinthe_test.exs
@@ -64,12 +64,35 @@ defmodule Nested.PetsSchema do
       arg(:name, :string)
       resolve(fn _, _, _ -> {:ok, %{}} end)
     end
+
+    # :user is referenced in the code examples in the documentation,
+    # the :user field and object are needed to pass the doctest.
+    field :user, :user do
+      arg(:name, :string)
+      resolve(fn _, _, _ -> {:ok, %{}} end)
+    end
   end
 
   mutation do
     field :add_person, :person do
       arg(:input, :add_person_input)
       resolve(fn _, _, _ -> {:ok, %{}} end)
+    end
+  end
+
+  object :user do
+    field :name, :string do
+      resolve(fn _, _, _ -> {:ok, "Bob"} end)
+    end
+
+    field :posts, non_null(list_of(:post)) do
+      resolve(fn _, _, _ -> {:ok, [%{}]} end)
+    end
+  end
+
+  object :post do
+    field :title, :string do
+      resolve(fn _, _, _ -> {:ok, "A post"} end)
     end
   end
 end


### PR DESCRIPTION
@devonestes thank you so much for your hard work on this project! As noted in https://github.com/devonestes/assertions/pull/27, there are some failing doctests. This is simply because the :user object referred to in the code examples in the documentation was not included in the test schema data. I believe that this PR will resolve those failing doctests, and I _think_ should fix the failing build (can't guarantee that second part).

Hope this is helpful, please let me know if there's anything you'd like handled differently! Also, I experimented around a bit, so there are a few commits in this PR - please squash them, if you should decide to accept.