### PR TITLE
Fixes code examples causing failing doctest.

### DIFF
--- a/lib/assertions/absinthe.ex
+++ b/lib/assertions/absinthe.ex
@@ -55,16 +55,9 @@ defmodule Assertions.Absinthe do
 
         iex> document_for(:user, 2)
         \"""
-        name
-        age
-        posts {
-          title
-          subtitle
-        }
-        comments {
-          body
-        }
+                    posts {\n                  title\n                  __typename\n                }\n                name\n                __typename
         \"""
+
     """
     @spec document_for(module(), atom(), non_neg_integer(), Keyword.t()) :: String.t()
     def document_for(schema, type, nesting, overrides) do
@@ -84,8 +77,9 @@ defmodule Assertions.Absinthe do
     ## Example
 
         iex> query = "{ user { #{document_for(:user, 2)} } }"
-        iex> expected = %{"user" => %{"name" => "Bob", "posts" => [%{"title" => "A post"}]}}
+        iex> expected = %{"user" => %{"__typename" => "User", "name" => "Bob", "posts" => [%{"__typename" => "Post", "title" => "A post"}]}}
         iex> assert_response_equals(query, expected)
+
     """
     @spec assert_response_equals(module(), String.t(), map(), Keyword.t()) :: :ok | no_return()
     def assert_response_equals(schema, document, expected_response, options) do
@@ -104,9 +98,10 @@ defmodule Assertions.Absinthe do
 
         iex> query = "{ user { #{document_for(:user, 2)} } }"
         iex> assert_response_matches(query) do
-           %{"user" => %{"name" => "B" <> _, "posts" => posts}}
-        end
+        ...>%{"user" => %{"name" => "B" <> _, "posts" => posts}}
+        ...>end
         iex> assert length(posts) == 1
+
     """
     @spec assert_response_matches(module(), String.t(), Keyword.t(), Macro.expr()) ::
             :ok | no_return()

--- a/test/assertions/absinthe_test.exs
+++ b/test/assertions/absinthe_test.exs
@@ -50,6 +50,22 @@ defmodule Nested.PetsSchema do
     end
   end
 
+  object :user do
+    field :name, :string do
+      resolve(fn _, _, _ -> {:ok, "Bob"} end)
+    end
+
+    field :posts, non_null(list_of(:post)) do
+      resolve(fn _, _, _ -> {:ok, [%{}]} end)
+    end
+  end
+
+  object :post do
+    field :title, :string do
+      resolve(fn _, _, _ -> {:ok, "A post"} end)
+    end
+  end
+
   input_object :add_person_input do
     field(:name, :string)
   end
@@ -61,6 +77,13 @@ defmodule Nested.PetsSchema do
     end
 
     field :dog, :dog do
+      arg(:name, :string)
+      resolve(fn _, _, _ -> {:ok, %{}} end)
+    end
+
+    # :user is referenced in the code examples in the documentation,
+    # the :user field and object are needed to pass the doctest.
+    field :user, :user do
       arg(:name, :string)
       resolve(fn _, _, _ -> {:ok, %{}} end)
     end


### PR DESCRIPTION
@devonestes thank you so much for your hard work on this project! As noted in #27, there are some failing doctests. This is simply because the :user object referred to in the code examples in the documentation was not included in the test schema data. I believe that this PR will resolve those failing doctests, and I think should fix the failing build (can't guarantee that second part).

Hope this is helpful, please let me know if there's anything you'd like handled differently!