### PR TITLE
Fix compilation error with Elixir 1.18

### DIFF
--- a/lib/assertions/comparisons.ex
+++ b/lib/assertions/comparisons.ex
@@ -13,7 +13,7 @@ defmodule Assertions.Comparisons do
   def compare_lists(left, right, comparison \\ &Kernel.==/2)
       when is_list(left) and is_list(right) do
     {left_diff, right_diff} =
-      Enum.reduce(1..length(left), {left, right}, &compare(&1, &2, comparison))
+      Enum.reduce(1..length(left)//1, {left, right}, &compare(&1, &2, comparison))
 
     {left_diff, right_diff, left_diff == [] and right_diff == []}
   end


### PR DESCRIPTION
I ran into this warning while adapting Elixir 1.18 for my project. I hope this PR could help others who are facing the same issue as me.

My env:

- macOS 14.4.1 (23E224)
- Erlang/OTP 27 [erts-15.1.1] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit]
- Elixir 1.18.0 (compiled with Erlang/OTP 27)

```
warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (assertions 0.20.1) lib/assertions/comparisons.ex:16: Assertions.Comparisons.compare_lists/3
  (assertions 0.20.1) lib/assertions/comparisons.ex:7: Assertions.Comparisons.compare_maps/3
```